### PR TITLE
Support course names containing slashes

### DIFF
--- a/bin/moodle
+++ b/bin/moodle
@@ -53,6 +53,10 @@ def course_download(moodle, url, directory=""):
    logging.debug(course)
    documents = moodle.get_documents(course)
    logging.debug(documents)
+
+   # Sanitize directory name
+   directory = directory.replace('/', '_')
+
    if directory and not os.path.exists(directory):
        logging.info("Directory of the subsection didn't exit")
        os.mkdir(directory)

--- a/bin/moodle
+++ b/bin/moodle
@@ -69,6 +69,11 @@ def course_download(moodle, url, directory=""):
            logging.info("Dir for week {!s}".format(index))
            dir_name = os.path.join(directory, "Week " + str(index))
        logging.debug(dir_name)
+
+       if not documents:
+           logging.info("No material for this category, skipping")
+           continue
+
        if not os.path.exists(dir_name):
            logging.info("Dir doesn't exist yet, creating it")
            os.mkdir(dir_name)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 setup(
       name='epfl-moodle',
-      version = '0.5.0',
+      version = '0.6.0',
       description = 'A simple interface to moodle',
       author = 'gcmalloc',
       url = 'http://github.com/gcmalloc/epfl-moodle',


### PR DESCRIPTION
New year, new classes, new issues ;)

I discovered while downloading the slides for "TCP/IP" that a slash is causing issues with `os.mkdir`. This PR fixes that.

I also added a patch to prevent creation of empty folders which are just annoying when searching for documents.